### PR TITLE
fix: [CIP] Upgrade available from openjdk:19-jdk-bullseye to openjdk:undefined

### DIFF
--- a/images/java/19/jdk-bullseye-newrelic/Dockerfile
+++ b/images/java/19/jdk-bullseye-newrelic/Dockerfile
@@ -1,5 +1,5 @@
 # Java 17 buster iamge with newrelic
-FROM openjdk:19-jdk-bullseye
+FROM openjdk:undefined
 
 ENV CONTAINER_PATH "/var/www"
 ENV NEW_RELIC_LICENSE_KEY ""


### PR DESCRIPTION
Changes included in this PR:
    * images/java/19/jdk-bullseye-newrelic/Dockerfile