### PR TITLE
fix: [CIP] Upgrade available from node:16.20.0-buster to node:16.20.1-buster

### DIFF
--- a/images/node/16/buster/Dockerfile
+++ b/images/node/16/buster/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image.
-FROM node:16.20.0-buster
+FROM node:16.20.1-buster
 
 # Install Certificates and Timezone data
 RUN apt-get -y install ca-certificates tzdata 


### PR DESCRIPTION
Changes included in this PR:
    * images/node/16/buster/Dockerfile