### PR TITLE
fix: [CIP] Upgrade available from golang:1.19.10-bullseye to golang:1.19.12-bullseye

### DIFF
--- a/images/golang/1.19/bullseye/Dockerfile
+++ b/images/golang/1.19/bullseye/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image
-FROM golang:1.19.10-bullseye
+FROM golang:1.19.12-bullseye
 
 # Update and upgrade packages
 RUN apt-get update && \


### PR DESCRIPTION
Changes included in this PR:
    * images/golang/1.19/bullseye/Dockerfile