### PR TITLE
fix: [CIP] Upgrade available from node:16.20.0-alpine to node:16.20.2-alpine

### DIFF
--- a/images/node/16/alpine/Dockerfile
+++ b/images/node/16/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image
-FROM node:16.20.0-alpine
+FROM node:16.20.2-alpine
 
 # Update and upgrade packages
 RUN apk update && \


### PR DESCRIPTION
Changes included in this PR:
    * images/node/16/alpine/Dockerfile