### PR TITLE
fix: [CIP] Upgrade available from python:3.10.12-slim to python:3.10.13-slim

### DIFF
--- a/images/python/3.10/slim/Dockerfile
+++ b/images/python/3.10/slim/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image.
-FROM python:3.10.12-slim
+FROM python:3.10.13-slim
 
 # Update and upgrade packages
 RUN apt-get update && \


### PR DESCRIPTION
Changes included in this PR:
    * images/python/3.10/slim/Dockerfile