### PR TITLE
fix: [CIP] Upgrade available from golang:1.20.5-alpine to golang:1.20.8-alpine

### DIFF
--- a/images/golang/1.20/alpine/Dockerfile
+++ b/images/golang/1.20/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image
-FROM golang:1.20.5-alpine
+FROM golang:1.20.8-alpine
 
 ENV PATH /usr/local/go/bin:$PATH
 


### PR DESCRIPTION
Changes included in this PR:
    * images/golang/1.20/alpine/Dockerfile