### PR TITLE
fix: [CIP] Upgrade available from golang:1.19.10-alpine to golang:1.19.13-alpine

### DIFF
--- a/images/golang/1.19/alpine/Dockerfile
+++ b/images/golang/1.19/alpine/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image
-FROM golang:1.19.10-alpine
+FROM golang:1.19.13-alpine
 
 ENV PATH /usr/local/go/bin:$PATH
 


### PR DESCRIPTION
Changes included in this PR:
    * images/golang/1.19/alpine/Dockerfile