### PR TITLE
fix: [CIP] Upgrade available from amazoncorretto:17.0.7-alpine to amazoncorretto:17.0.9-alpine

### DIFF
--- a/images/java/17/jdk-alpine-newrelic/Dockerfile
+++ b/images/java/17/jdk-alpine-newrelic/Dockerfile
@@ -1,5 +1,5 @@
 # Java 17 jdk alpine image
-FROM amazoncorretto:17.0.7-alpine
+FROM amazoncorretto:17.0.9-alpine
 
 # Update and upgrade packages
 RUN apk update && \


### PR DESCRIPTION
Changes included in this PR:
    * images/java/17/jdk-alpine-newrelic/Dockerfile