### PR TITLE
fix: [CIP] Upgrade available from php:8.1.20-fpm-alpine to php:8.1.26-fpm-alpine

### DIFF
--- a/images/php/8.1/fpm-alpine/Dockerfile
+++ b/images/php/8.1/fpm-alpine/Dockerfile
@@ -1,5 +1,5 @@
 # fpm-alpine
-FROM php:8.1.20-fpm-alpine
+FROM php:8.1.26-fpm-alpine
 
 ENV stdout /dev/stdout
 ENV stderr /dev/stderr


### PR DESCRIPTION
Changes included in this PR:
    * images/php/8.1/fpm-alpine/Dockerfile