### PR TITLE
fix: [CIP] Upgrade available from node:18.16.0-bullseye to node:18.19.0-bullseye

### DIFF
--- a/images/node/18/bullseye/Dockerfile
+++ b/images/node/18/bullseye/Dockerfile
@@ -1,5 +1,5 @@
 # Create a minimal image.
-FROM node:18.16.0-bullseye
+FROM node:18.19.0-bullseye
 
 # Install Certificates and Timezone data
 RUN apt-get -y install ca-certificates tzdata 


### PR DESCRIPTION
Changes included in this PR:
    * images/node/18/bullseye/Dockerfile