### PR TITLE
fix: [CIP] Upgrade available from amazoncorretto:11.0.19-alpine to amazoncorretto:11.0.22-alpine

### DIFF
--- a/images/java/11/jdk-alpine-newrelic/Dockerfile
+++ b/images/java/11/jdk-alpine-newrelic/Dockerfile
@@ -1,5 +1,5 @@
 # Java jdk alpine image
-FROM amazoncorretto:11.0.19-alpine
+FROM amazoncorretto:11.0.22-alpine
 
 # Update and upgrade packages
 RUN apk update && \


### PR DESCRIPTION
Changes included in this PR:
    * images/java/11/jdk-alpine-newrelic/Dockerfile