### PR TITLE
fix: [CIP] Upgrade available from amazoncorretto:11.0.19 to amazoncorretto:11.0.22

### DIFF
--- a/images/java/11/jdk-amazon-newrelic/Dockerfile
+++ b/images/java/11/jdk-amazon-newrelic/Dockerfile
@@ -1,5 +1,5 @@
 # Java 11 jdk image
-FROM amazoncorretto:11.0.19
+FROM amazoncorretto:11.0.22
 
 RUN yum update -y --security
 


### PR DESCRIPTION
Changes included in this PR:
    * images/java/11/jdk-amazon-newrelic/Dockerfile