### PR TITLE
fix: [CIP] Upgrade available from amazoncorretto:17.0.7 to amazoncorretto:17.0.10

### DIFF
--- a/images/java/17/jdk-amazon-newrelic/Dockerfile
+++ b/images/java/17/jdk-amazon-newrelic/Dockerfile
@@ -1,5 +1,5 @@
 # Java 17 jdk image
-FROM amazoncorretto:17.0.7
+FROM amazoncorretto:17.0.10
 
 RUN yum update -y --security
 


### PR DESCRIPTION
Changes included in this PR:
    * images/java/17/jdk-amazon-newrelic/Dockerfile